### PR TITLE
added the PR request template to the repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+<!-- Brief description of what this PR does and why -->
+
+## Type of Change
+
+- [ ] New feature
+- [ ] Bug fix
+- [ ] Refactor
+- [ ] Docs / config
+
+## Related
+
+- Closes #<!-- issue/backlog item number -->
+- Feature: <!-- e.g. OrderManager, UserCreation, PaymentHandler -->
+
+## What Was Done
+
+## <!-- 2-4 bullet points describing the changes -->
+
+-
+
+## Testing
+
+- [ ] Manually tested locally
+- [ ] Pylint passes with no new errors
+- [ ] Existing functionality not broken
+
+## Notes for Reviewer
+
+<!-- Anything the reviewer should know  tricky logic? , known limitations, follow up tasks -->


### PR DESCRIPTION
Added the pr request template that we will use throughout the project M3. This is important just for standards and will be automatically put into the pr description when opening a new pr. simple change with no code logic