### PR TITLE
Configure SECRET_KEY for pytest execution

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -33,4 +33,6 @@ jobs:
           pylint app/ --fail-under=5
 
       - name: Run tests
+        env:
+          SECRET_KEY: ${{ secrets.SECRET_KEY }}
         run: pytest


### PR DESCRIPTION
NOTE: the tests are failing because the 2 prs open at this time (#139 and this one #140) depend on each other to work, the other pr has UserCreate, which is why this test is failing
## Summary
Add SECRET_KEY environment variable for tests, had to add this because all tests up until now have not imported main, and config.py (something I added in feature 1) has SECRET_KEY with no default (because I was lazy) so pydantic throws the app loads.
<!-- Brief description of what this PR does and why -->

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs / config

## Related Issue

Closes #<!-- issue number -->

## Changes Made

<!--  2-4 bullet points -->
-
-

## Acceptance Criteria

<!-- List the acceptance criteria from the issue and confirm they are met -->
-
-

## Testing
This is for testing
## Notes for Reviewer

<!-- Tricky logic?, known limitations?, follow-up tasks??? -->
