### PR TITLE
added for PR2, depends in routes, deliveryupdate in schemas, update

### DIFF
--- a/app/routers/Delivery.py
+++ b/app/routers/Delivery.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
-from app.schemas.Delivery import Delivery, DeliveryCreate, DeliveryUpdate
+from app.core.dependencies import get_current_user, require_role
+from app.schemas.Delivery import DeliveryCreate, DeliveryStatusUpdate, DeliveryUpdate
+from app.schemas.User import UserRole
 from app.services.DeliveryService import DeliveryService
 
 router = APIRouter(
@@ -10,31 +12,36 @@ router = APIRouter(
 service = DeliveryService()
 
 
-@router.get("/")
+@router.get("/", dependencies=[Depends(get_current_user)])
 async def get_all_deliveries():
     return service.get_all()
 
 
-@router.get("/order/{order_id}")
+@router.get("/order/{order_id}", dependencies=[Depends(get_current_user)])
 async def get_delivery_by_order(order_id: str):
     return service.get_by_order_id(order_id)
 
 
-@router.get("/{delivery_id}")
+@router.get("/{delivery_id}", dependencies=[Depends(get_current_user)])
 async def get_delivery(delivery_id: str):
     return service.get_delivery(delivery_id)
 
 
-@router.post("/")
+@router.post("/", dependencies=[Depends(require_role([UserRole.ADMIN, UserRole.RESTAURANT_OWNER]))])
 async def create_delivery(delivery: DeliveryCreate):
     return service.create_delivery(delivery)
 
 
-@router.put("/{delivery_id}")
+@router.put("/{delivery_id}", dependencies=[Depends(require_role([UserRole.ADMIN, UserRole.RESTAURANT_OWNER]))])
 async def update_delivery(delivery_id: str, delivery: DeliveryUpdate):
     return service.update_delivery(delivery_id, delivery)
 
 
-@router.delete("/{delivery_id}")
+@router.patch("/{delivery_id}/status", dependencies=[Depends(require_role([UserRole.ADMIN, UserRole.RESTAURANT_OWNER]))])
+async def update_delivery_status(delivery_id: str, body: DeliveryStatusUpdate):
+    return service.update_status(delivery_id, body.status)
+
+
+@router.delete("/{delivery_id}", dependencies=[Depends(require_role([UserRole.ADMIN]))])
 async def delete_delivery(delivery_id: str):
     return service.delete_delivery(delivery_id)

--- a/app/schemas/Delivery.py
+++ b/app/schemas/Delivery.py
@@ -34,3 +34,7 @@ class DeliveryUpdate(BaseModel):
     driver_id: Optional[str]
     address: Optional[str]
     instructions: Optional[str]
+
+
+class DeliveryStatusUpdate(BaseModel):
+    status: DeliveryStatus

--- a/app/services/DeliveryService.py
+++ b/app/services/DeliveryService.py
@@ -11,6 +11,8 @@ from app.schemas.Delivery import (
     DeliveryStatus,
     DeliveryUpdate,
 )
+from app.schemas.Order import OrderStatus, OrderUpdate
+from app.services.OrderService import OrderService
 
 VALID_TRANSITIONS = {
     DeliveryStatus.ASSIGNED: [DeliveryStatus.IN_TRANSIT],
@@ -68,6 +70,23 @@ class DeliveryService:
                 if delivery.instructions is not None:
                     d.instructions = delivery.instructions
                 save_all(deliveries)
+                return d
+        raise HTTPException(status_code=404, detail="Delivery not found")
+
+    def update_status(self, delivery_id: str, new_status: DeliveryStatus) -> Delivery:
+        deliveries = load_all()
+        for d in deliveries:
+            if d.delivery_id == delivery_id:
+                if new_status not in VALID_TRANSITIONS[d.status]:
+                    raise HTTPException(status_code=422, detail=f"Invalid status transition: {d.status} -> {new_status}")
+                d.status = new_status
+                if new_status == DeliveryStatus.DELIVERED:
+                    d.completed_at = datetime.now(timezone.utc).isoformat()
+                save_all(deliveries)
+                if new_status == DeliveryStatus.IN_TRANSIT:
+                    OrderService().update_order(d.order_id, OrderUpdate(status=OrderStatus.OUT_FOR_DELIVERY))
+                if new_status == DeliveryStatus.DELIVERED:
+                    OrderService().update_order(d.order_id, OrderUpdate(status=OrderStatus.DELIVERED))
                 return d
         raise HTTPException(status_code=404, detail="Delivery not found")
 

--- a/tests/test_delivery.py
+++ b/tests/test_delivery.py
@@ -3,20 +3,41 @@ from fastapi.testclient import TestClient
 from unittest.mock import patch
 
 from main import app
+from app.core.dependencies import get_current_user, require_role
 from app.schemas.Delivery import Delivery, DeliveryStatus
+from app.schemas.User import User, UserRole
+
+MOCK_ADMIN = User(
+    user_id="admin-1",
+    username="admin",
+    email="admin@example.com",
+    password_hash="hashed",
+    phone="0000000000",
+    role=UserRole.ADMIN,
+    location="HQ",
+    postal_code="V1V1V1",
+    created_at="2026-01-01",
+)
+
+app.dependency_overrides[get_current_user] = lambda: MOCK_ADMIN
 
 client = TestClient(app)
 
-MOCK_DELIVERY = Delivery(
-    delivery_id="test-id-123",
-    order_id="order-1",
-    driver_id="driver-1",
-    status=DeliveryStatus.ASSIGNED,
-    address="123 Main St",
-    instructions="Leave at door",
-    created_at="2026-03-13T00:00:00+00:00",
-    completed_at=None,
-)
+def make_delivery(**overrides):
+    defaults = dict(
+        delivery_id="test-id-123",
+        order_id="order-1",
+        driver_id="driver-1",
+        status=DeliveryStatus.ASSIGNED,
+        address="123 Main St",
+        instructions="Leave at door",
+        created_at="2026-03-13T00:00:00+00:00",
+        completed_at=None,
+    )
+    return Delivery(**{**defaults, **overrides})
+
+
+MOCK_DELIVERY = make_delivery()
 
 
 @patch("app.services.DeliveryService.load_all", return_value=[MOCK_DELIVERY])
@@ -93,6 +114,28 @@ def test_update_delivery_not_found(mock_save, mock_load):
         "instructions": "Ring bell",
     }
     response = client.put("/delivery/nonexistent", json=payload)
+    assert response.status_code == 404
+
+
+@patch("app.services.DeliveryService.save_all")
+@patch("app.services.DeliveryService.OrderService")
+def test_update_status_valid_transition(mock_order_service, mock_save):
+    with patch("app.services.DeliveryService.load_all", return_value=[make_delivery()]):
+        response = client.patch("/delivery/test-id-123/status", json={"status": "IN_TRANSIT"})
+    assert response.status_code == 200
+    assert response.json()["status"] == "IN_TRANSIT"
+
+
+@patch("app.services.DeliveryService.save_all")
+def test_update_status_invalid_transition(mock_save):
+    with patch("app.services.DeliveryService.load_all", return_value=[make_delivery()]):
+        response = client.patch("/delivery/test-id-123/status", json={"status": "DELIVERED"})
+    assert response.status_code == 422
+
+
+@patch("app.services.DeliveryService.load_all", return_value=[])
+def test_update_status_not_found(mock_load):
+    response = client.patch("/delivery/nonexistent/status", json={"status": "IN_TRANSIT"})
     assert response.status_code == 404
 
 


### PR DESCRIPTION
## Summary
Adds auth enforcement and order status sync to the delivery system. Restaurant owners and admins can now manage delivery status transitions, which automatically go on to the linked order.??
<!-- Brief description of what this PR does and why -->

## Type of Change
- New feature! BABY!
- [ ] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs / config

## Related Issue
Closes #73, #75, #76, #77
Closes #<!-- issue number -->

## Changes Made

<!--  2-4 bullet points -->
- Added DeliveryStatusUpdate schema and PATCH /delivery/{id}/status endpoint for clean status-only updates
- Added role based auth to all delivery routes (any authenticated user for GETs, RESTAURANT_OWNER/ADMIN for mutations, ADMIN-only for delete)
- Added update_status service method with transition validation that syncs order status (IN_TRANSIT → order OUT_FOR_DELIVERY, DELIVERED → order DELIVERED)

## Acceptance Criteria

<!-- List the acceptance criteria from the issue and confirm they are met -->
- Restaurant owner can mark a delivery as out for delivery (IN_TRANSIT), updating the linked order to OUT_FOR_DELIVERY
- Restaurant owner can mark a delivery as completed (DELIVERED), updating the linked order to DELIVERED
- Customer can view delivery status via GET /delivery/{id} or GET /delivery/order/{order_id}
- Unauthenticated requests are rejected with 401; insufficient role returns 403

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All tests pass locally (`pytest`)
- [ ] Pylint passes (`pylint app/`)

## Notes for Reviewer
can you find the bug? if any?
<!-- Tricky logic?, known limitations?, follow-up tasks??? -->
