### PR TITLE
Menu Storing (Feature 2)

### DIFF
--- a/app/routers/MenuItem.py
+++ b/app/routers/MenuItem.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from app.schemas.MenuItem import MenuItem, MenuItemCreate, MenuItemUpdate
 from app.services.MenuItemService import MenuItemService
@@ -13,25 +13,28 @@ service = MenuItemService()
 
 
 @router.get("/")
-async def get_all_menu_items():
+async def get_all_menu_items(service: MenuItemService = Depends()):
     return service.get_menu_items()
 
+@router.get("/restaurant/{restaurant_id}")
+async def get_menu_by_restaurant(restaurant_id: str, service: MenuItemService = Depends()):
+    return service.get_menu_by_restaurant(restaurant_id)
 
 @router.get("/{item_id}")
-async def get_menu_item(item_id: str):
+async def get_menu_item(item_id: str, service: MenuItemService = Depends()):
     return service.get_menu_item(item_id)
 
 
 @router.post("/")
-async def create_menu_item(menu_item: MenuItemCreate):
+async def create_menu_item(menu_item: MenuItemCreate, service: MenuItemService = Depends()):
     return service.create_menu_item(menu_item)
 
 
 @router.put("/{item_id}")
-async def update_menu_item(item_id: str, menu_item: MenuItemUpdate):
+async def update_menu_item(item_id: str, menu_item: MenuItemUpdate, service: MenuItemService = Depends()):
     return service.update_menu_item(item_id, menu_item)
 
 
 @router.delete("/{item_id}")
-async def delete_menu_item(item_id: str):
+async def delete_menu_item(item_id: str, service: MenuItemService = Depends()):
     return service.delete_menu_item(item_id)

--- a/app/schemas/MenuItem.py
+++ b/app/schemas/MenuItem.py
@@ -1,4 +1,5 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+from typing import Optional
 
 class MenuItem(BaseModel):
     item_id: str
@@ -10,16 +11,16 @@ class MenuItem(BaseModel):
     category: str
 
 class MenuItemCreate(BaseModel):
-    restaurant_id: str
-    name: str
-    description: str
-    price: float
-    category: str
+    restaurant_id: str = Field(..., min_length=1, description="Must link to a restaurant")
+    name: str = Field(..., min_length=1)
+    description: str = Field(..., min_length=1)
+    price: float = Field(..., gt=0, description="Price must be greater than 0")
+    category: str = Field(..., min_length=1)
     
 class MenuItemUpdate(BaseModel):
-    restaurant_id: str
-    name: str
-    description: str
-    price: float
-    is_available: bool
-    category: str
+    restaurant_id: Optional[str] = Field(None, min_length=1)
+    name: Optional[str]= Field(None, min_length=1)
+    description: Optional[str] = Field(None, min_length=1)
+    price: Optional[float] = Field(None, gt=1)
+    is_available: Optional[bool] = None
+    category: Optional[str] = Field(None, min_length=1)

--- a/app/services/MenuItemService.py
+++ b/app/services/MenuItemService.py
@@ -4,22 +4,38 @@ from fastapi import HTTPException
 
 from app.models.MenuItemModel import load_all, save_all
 from app.schemas.MenuItem import MenuItem, MenuItemCreate, MenuItemUpdate
+from app.services.Restaurant_service import RestaurantService
 
 
 class MenuItemService:
+    def __init__(self):
+        self.restaurant_service = RestaurantService()
+
+    def _check_restaurant_exists(self, restaurant_id: str):
+        if not self.restaurant_service.get_restaurant(restaurant_id):
+            raise HTTPException(status_code=400, detail="Valid restaurant ID is required.")
+
     def get_menu_items(self):
         return load_all()
+    
+    def get_menu_by_restaurant(self, restaurant_id: str):
+        self._check_restaurant_exists(restaurant_id)
+        return [mi for mi in load_all() if mi.restaurant_id == restaurant_id]
 
     def create_menu_item(self, menu_item: MenuItemCreate) -> MenuItem:
-        new_menu_item = MenuItem(item_id=str(uuid.uuid4()), **menu_item.model_dump(), is_available=True)  #
-        save_all([new_menu_item])
+        self._check_restaurant_exists(menu_item.restaurant_id)
+        menu_items = load_all()
+        new_menu_item = MenuItem(item_id=str(uuid.uuid4()), **menu_item.model_dump(), is_available=True)
+        menu_items.append(new_menu_item)
+        save_all(menu_items)
         return new_menu_item
 
     def update_menu_item(self, item_id: str, menu_item: MenuItemUpdate):
         menu_items = load_all()
         for mi in menu_items:
             if mi.item_id == item_id:
-                for k, v in menu_item.model_dump().items():
+                update_data = menu_item.model_dump(exclude_unset=True)
+                for k, v in update_data.items():
                     setattr(mi, k, v)
                 save_all(menu_items)
                 return mi
@@ -31,7 +47,7 @@ class MenuItemService:
             if mi.item_id == item_id:
                 menu_items.remove(mi)
                 save_all(menu_items)
-                return True
+                return {"message": "Menu item deleted"}
         raise HTTPException(status_code=404, detail="Menu item not found")
 
     def get_menu_item(self, item_id: str) -> MenuItem:

--- a/tests/test_menuitem_service.py
+++ b/tests/test_menuitem_service.py
@@ -54,11 +54,12 @@ def test_get_menu_item_not_found(mock_load):
         service.get_menu_item("does-not-exist")
     assert exc.value.status_code == 404
 
-
+@patch("app.services.MenuItemService.MenuItemService._check_restaurant_exists")
 @patch("app.services.MenuItemService.save_all")
 @patch("app.services.MenuItemService.load_all")
-def test_create_menu_item(mock_load, mock_save):
+def test_create_menu_item(mock_load, mock_save, mock_check):
     mock_load.return_value = []
+    mock_check.return_value = None
     service = MenuItemService()
     result = service.create_menu_item(make_menu_item_create())
     assert result.name == "Pepperoni Pizza"
@@ -95,7 +96,7 @@ def test_update_menu_item_not_found(mock_load):
                 restaurant_id="x",
                 name="x",
                 description="x.",
-                price=0.0,
+                price=5.99,
                 is_available=False,
                 category="x"
             ),


### PR DESCRIPTION
## Summary
All menu items are strictly linked to an existing restaurant before creation. It enforces data validation to prevent empty fields and negative prices. Also patches a bug in the service layer that was wiping the `menu_items.csv` database upon new item creation.

## Type of Change
- [x] New feature 
- [x] Bug fix
- [ ] Refactor
- [ ] Docs / config

## Related Issue
Closes #18, closes #19, closes #20, closes #21, closes #22

## Changes Made
* Added Pydantic `Field` rules to `MenuItem` schemas to block empty strings and enforce `price > 0`.
* Updated `MenuItemService` to import `RestaurantService` and verify `restaurant_id` existence before saving.
* Fixed the `save_all()` bug in `create_menu_item` to correctly append to the existing database list rather than overwriting it.
* Updated mocked tests in `test_menuitem_service.py` to handle the new validation and dependency rules.

## Acceptance Criteria
- [x] Restaurant owners can create and store restaurant profiles with required details (name, description, address, hours)
- [x] Restaurant owners can add, update, and remove menu items associated with their restaurant
- [x] Each menu item must be linked to exactly one existing restaurant
- [x] Required fields for restaurants and menu items (e.g., name, price) cannot be empty or null
- [x] Menu item prices must be valid and greater than zero
- [x] The system prevents saving or displaying menu items with invalid or missing data

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally (`pytest`)

## Notes for Reviewer